### PR TITLE
[WIP]電話番号認証ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/_member-sms-confirmation.scss
+++ b/app/assets/stylesheets/_member-sms-confirmation.scss
@@ -1,0 +1,255 @@
+.member-sms-confirmation-wrapper {
+  height: 100%;
+  width: 100%;
+  background-color: #f2f2f2;
+  font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
+}
+  .member-sms-confirmation-header {
+    width: 1372px;
+    height: 128px;
+    text-align: center;
+    margin: auto;
+    position: relative;
+    .sms-confirmation-merukari-logo {
+      display: inline-block;
+      .confirmation_merukari {
+        margin-top: 40px;
+        margin-right: 550px;
+        display: inline-block;
+      }
+    }
+    .member-sms-confirmation-progress {
+      display: inline-block;
+      width: 552px;
+      height: 38px;
+      list-style: none;
+      position: absolute;
+      top: 40px;
+      right: 300px;
+
+      li {
+        display: inline-block;
+      }
+      li:nth-of-type(5)  {
+        margin-right: 0px;
+      }
+
+      .progress {
+        color: #888;
+        font-size: 12px;
+        margin-right: 40px;
+        position: relative;
+        .progress-parts {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ccc;
+          margin: auto;
+          margin-top: 3px;
+        }
+
+        .progress-parts_1 {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ea352d;
+          margin: auto;
+          margin-top: 3px;
+        }
+        .progress-parts_1::after {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ea352d;
+          display: block;
+          width: 100%;
+          line-height: 3px;
+          position: absolute;
+          left: 50%;
+          bottom: 5px;
+        }
+
+        .progress-parts_5 {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ccc;
+          margin: auto;
+          margin-top: 3px;
+        }
+        .progress-parts_5::before {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 120%;
+          line-height: 2px;
+          position: absolute;
+          right: 50%;
+          bottom: 5px;
+        }
+
+        .progress-parts::before {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          right: 50%;
+          bottom: 5px;
+        }
+
+        .progress-parts::after {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          left: 50%;
+          bottom: 5px;
+        }
+      }
+      
+      .progress-here {
+        color: #ea352d;
+        font-size: 12px;
+        margin-right: 40px;
+        position: relative;
+        z-index: 3;
+        .progress-parts_here {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ea352d;
+          margin: auto;
+          margin-top: 3px;         
+        }
+        .progress-parts_here::before {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ea352d;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          right: 50%;
+          bottom: 5px;
+          z-index: -1;
+        }
+        .progress-parts_here::after {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          left: 50%;
+          bottom: 5px;
+          z-index: -1;
+        }
+      }
+    }
+  }
+  .member-sms-confirmation-menu {
+    height: 498px;
+    width: 100%;
+    &__contents {
+      width: 700px;
+      height: 498px;
+      margin: 0 auto;
+      text-align: center;
+      background-color: white;
+    }
+      &__top {
+        box-sizing: border-box;
+        height: 95px;
+        padding: 32px;
+        background-color: white;
+        font-size: 22px;
+        font-weight: bold;
+        border-bottom: solid 1px #f2f2f2;
+      }
+      &__form {
+        box-sizing: border-box;
+        height: 403px;
+        width: 700px;
+        padding: 40px 40px 64px;
+      }
+        .member-mobile_number {
+          display: inline-block;
+          width: 343px;
+          height: 70px;
+          label {
+            font-weight: 600;
+            font-size: 14px;
+            float: left;
+          }
+          .input-mobile-number-form {
+            box-sizing: border-box;
+            width: 100%;
+            height: 48px;
+            border-radius: 5px;
+            border: solid 1px #ccc;
+            padding: 10px 16px 8px;
+            margin-top: 3px;
+          }
+          P {
+            width: 100%;
+            font-size: 14px;
+            color: #333;
+            text-align: left;
+            margin-top: 8px;
+          }
+        }
+        .member-sms-confirmation-menu_button {
+          box-sizing: border-box;
+          border: solid 1px #ea352d;
+          width: 343px;
+          height: 50px;
+          line-height: 50px;
+          background-color: #ea352d;
+          color: white;
+          font-size: 13px;
+          margin: auto;
+          margin-top: 32px;          
+        }
+          p {
+            font-size: 14px;
+            color: #333;
+            width: 343px;
+            margin: auto;
+            margin-top: -10px;
+          }
+          .mobile-explanation-link {
+            color: #0099e8;
+            font-size: 14px;
+            width: 343px;
+            margin: auto;
+            margin-top: 32px;
+            text-align: right;
+          }
+            .yajirusi-next-page::before {
+              content: '>';
+              font-family: 'icon-font';
+              font-style: normal;
+              font-weight: 600;
+              font-variant: normal;
+              text-transform: none;
+              line-height: 1;
+              -webkit-font-smoothing: antialiased;
+            }
+  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import "mypage-left";
 @import "mypage";
 @import "member-registration";
+@import "member-sms-confirmation";

--- a/app/views/users/registrations/new_2.html.haml
+++ b/app/views/users/registrations/new_2.html.haml
@@ -1,1 +1,37 @@
-new2だよ
+.member-sms-confirmation-wrapper
+  .member-sms-confirmation-header
+    .sms-confirmation-merukari-logo
+      = image_tag "merikari4.png", size:'185x49',class: "confirmation_merukari"
+    .member-sms-confirmation-progress
+      %li.progress
+        会員情報
+        .progress-parts_1
+      %li.progress-here
+        電話番号認証
+        .progress-parts_here
+      %li.progress
+        お届け先住所入力
+        .progress-parts
+      %li.progress
+        支払い方法
+        .progress-parts
+      %li.progress
+        完了
+        .progress-parts_5
+  .member-sms-confirmation-menu
+    .member-sms-confirmation-menu__contents
+      %h2.member-sms-confirmation-menu__top
+        電話番号の確認
+      .member-sms-confirmation-menu__form
+        .member-mobile_number
+          %label 携帯電話の番号
+          %input.input-mobile-number-form{:name => "tell", :placeholder => "携帯電話の番号を入力", :type => "tell", :value => ""}/
+          %p 本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用して認証を行います。
+        .member-sms-confirmation-menu_button
+          SMSを送信する
+        %br
+          %p ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
+          .mobile-explanation-link
+            電話番号の確認が必要な理由
+            %i.yajirusi-next-page
+  = render "devise/registrations/footer-signup" 


### PR DESCRIPTION
What
電話番号認証ページ（https://www.mercari.com/jp/signup/sms_confirmation/）
のマークアップを行いました。

Why
携帯電話番号を入力するフォーム、送信ボタンのあるページです。フッターには進行状況がわかるように入力が済んだ工程から現在のページまでが赤くしてあります。
見た目のみ作りました。

●作成した見た目はこちらになります。フッターはこの前にLGTMをいただいたページと同じフッターを使っています。
https://gyazo.com/4e17b9f99778098b7fd1682f004e989a