### PR TITLE
SMS認証ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/_member-sms.scss
+++ b/app/assets/stylesheets/_member-sms.scss
@@ -288,7 +288,9 @@
             color: #0099e8;
             font-size: 14px;
             text-align: left;
+            margin: 0 auto;
             margin-top: 5px;
+            
           }
           .consent-message {
             box-sizing: border-box;
@@ -299,16 +301,14 @@
             text-align: left;
             margin: 0 auto;
             margin-top: 10px;
-            .consent-link {
-              color: #0099e8;
-              text-decoration: none;
-              transition: color 0.3s;
-              font-size: 13px;
-            }
-            a:hover {
-              color: #b3d4fc;
-              text-decoration: underline;
-            }
           }
         }
   }
+  a {
+    color: #0099e8;
+    text-decoration: none;
+  }
+  a:hover {
+    color: #b3d4fc;
+    text-decoration: underline;
+}

--- a/app/assets/stylesheets/_member-sms.scss
+++ b/app/assets/stylesheets/_member-sms.scss
@@ -1,0 +1,314 @@
+.member-sms-wrapper {
+  height: 100%;
+  width: 100%;
+  background-color: #f2f2f2;
+  font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
+}
+  .member-sms-confirmation-header {
+    width: 1372px;
+    height: 128px;
+    text-align: center;
+    margin: auto;
+    position: relative;
+    .sms-confirmation-merukari-logo {
+      display: inline-block;
+      .confirmation_merukari {
+        margin-top: 40px;
+        margin-right: 550px;
+        display: inline-block;
+      }
+    }
+    
+    .member-sms-confirmation-progress {
+      display: inline-block;
+      width: 552px;
+      height: 38px;
+      list-style: none;
+      position: absolute;
+      top: 40px;
+      right: 300px;
+
+      li {
+        display: inline-block;
+      }
+      li:nth-of-type(5)  {
+        margin-right: 0px;
+      }
+
+      .progress {
+        color: #888;
+        font-size: 12px;
+        margin-right: 40px;
+        position: relative;
+        .progress-parts {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ccc;
+          margin: auto;
+          margin-top: 3px;
+        }
+
+        .progress-parts_1 {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ea352d;
+          margin: auto;
+          margin-top: 3px;
+        }
+        .progress-parts_1::after {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ea352d;
+          display: block;
+          width: 100%;
+          line-height: 3px;
+          position: absolute;
+          left: 50%;
+          bottom: 5px;
+        }
+
+        .progress-parts_5 {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ccc;
+          margin: auto;
+          margin-top: 3px;
+        }
+        .progress-parts_5::before {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 120%;
+          line-height: 2px;
+          position: absolute;
+          right: 50%;
+          bottom: 5px;
+        }
+
+        .progress-parts::before {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          right: 50%;
+          bottom: 5px;
+        }
+        .progress-parts::after {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          left: 50%;
+          bottom: 5px;
+        }
+      }
+
+      .progress-here {
+        color: #ea352d;
+        font-size: 12px;
+        margin-right: 40px;
+        position: relative;
+        z-index: 3;
+        .progress-parts_here {
+          display: block;
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          background-color: #ea352d;
+          margin: auto;
+          margin-top: 3px;         
+        }
+        .progress-parts_here::before {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ea352d;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          right: 50%;
+          bottom: 5px;
+          z-index: -1;
+        }
+        .progress-parts_here::after {
+          content:'';
+          border-width: 2px 0px 0px 0px;
+          border-style: solid;
+          border-color: #ccc;
+          display: block;
+          width: 100%;
+          line-height: 2px;
+          position: absolute;
+          left: 50%;
+          bottom: 5px;
+          z-index: -1;
+        }
+      }
+    }
+  }
+  .member-mobile-number-menu {
+    height: 965px;
+    width: 100%;
+    &__contents {
+      height: 865px;
+      width: 700px;
+      background-color: white;
+      margin: 0 auto;
+      text-align: center;
+    }
+      &__top {
+        box-sizing: border-box;
+        height: 95px;
+        padding: 32px;
+        background-color: white;
+        font-size: 22px;
+        font-weight: bold;
+        border-bottom: solid 1px #f2f2f2;
+      }
+      &__first {
+        height: calc(865px - 95px);
+      }
+        &__main {
+          box-sizing: border-box;
+          height: 290px;
+          border-bottom: solid 1px #f2f2f2;
+          padding: 40px 40px 64px;
+        }
+          &__form {
+            display: inline-block;
+            width: 343px;
+            height: 70px;
+            label {
+              font-weight: 600;
+              font-size: 14px;
+              float: left;
+            }
+            .input-sms-mobile-number {
+              box-sizing: border-box;
+              width: 100%;
+              height: 48px;
+              border-radius: 5px;
+              border: solid 1px #ccc;
+              padding: 10px 16px 8px;
+              margin-top: 3px;
+            }
+            p {
+              width: 100%;
+              font-size: 14px;
+              color: #333;
+              text-align: left;
+              margin-top: 8px;
+            }
+          }
+          .form-input-complete-button {
+            box-sizing: border-box;
+            border: solid 1px #ea352d;
+            width: 343px;
+            height: 50px;
+            line-height: 50px;
+            background-color: #ea352d;
+            color: white;
+            font-size: 13px;
+            margin: auto;
+            margin-top: 32px; 
+          }
+        .not-sms-number {
+          box-sizing: border-box;
+          height: 240px;
+          padding: 40px 40px 64px;
+          border-bottom: solid 1px #f2f2f2;
+          &__text {
+            height: 50px;
+            width: 343px;
+            margin: 0 auto;
+            position: relative;
+            label {
+              font-weight: 600;
+              font-size: 14px;
+              position: absolute;
+              left: 0px;             
+            }
+            .to-call {
+              width: 100%;
+              font-size: 14px;
+              color: #333;
+              text-align: left;
+              position: relative;
+              top: 28px;
+            }
+                      
+          }
+          &__button {
+            box-sizing: border-box;
+            border: solid 1px #ea352d;
+            width: 343px;
+            height: 50px;
+            line-height: 50px;
+            background-color: #ea352d;
+            color: white;
+            font-size: 13px;
+            margin: auto;
+            margin-top: 32px; 
+          }
+        }
+        .one-more-mobile-number {
+          box-sizing: border-box;
+          height: 240px;
+          padding: 40px 40px 64px;
+          &__text {
+            width: 343px;
+            height: 50px;
+            text-align: left;
+            margin: 0 auto;
+            label {
+              font-weight: 600;
+              font-size: 15px;
+            }
+          }
+          .input-number-link {
+            width: 343px;
+            color: #0099e8;
+            font-size: 14px;
+            text-align: left;
+            margin-top: 5px;
+          }
+          .consent-message {
+            box-sizing: border-box;
+            width: 343px;
+            height: 50px;
+            font-size: 13px;
+            color: #333;
+            text-align: left;
+            margin: 0 auto;
+            margin-top: 10px;
+            .consent-link {
+              color: #0099e8;
+              text-decoration: none;
+              transition: color 0.3s;
+              font-size: 13px;
+            }
+            a:hover {
+              color: #b3d4fc;
+              text-decoration: underline;
+            }
+          }
+        }
+  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,4 @@
 @import "mypage";
 @import "member-registration";
 @import "member-sms-confirmation";
+@import "member-sms"

--- a/app/views/users/registrations/new_3.html.haml
+++ b/app/views/users/registrations/new_3.html.haml
@@ -26,7 +26,7 @@
         .member-mobile-number-menu__main
           .member-mobile-number-menu__form
             %label 認証番号
-            %input.input-sms-mobile-number{:name => "number", :placeholder => "認証番号を入力", :type => "number", :value => ""}/
+            %input.input-sms-mobile-number{ name: "number", placeholder: "認証番号を入力", type: "text", value: ""}/
             %p SMSで届いた認証番号を入力してください
           .form-input-complete-button
             認証して完了
@@ -39,10 +39,11 @@
         .one-more-mobile-number
           .one-more-mobile-number__text
             %label 認証番号を再送することもできます。もう一度電話番号を入力して下さい。
-          %a.input-number-link 電話番号を再度入力する
+          .input-number-link
+            = link_to '電話番号を再度入力する', "https://www.mercari.com/jp/"
           %p.consent-message 
             ※SMSが届かない場合は
-            %a.consent-link{:href => "https://www.mercari.com/jp/"}> SMS受信設定
+            =link_to 'SMS受信設定', "https://www.mercari.com/jp/"
             を確認して、もう一度電話番号を入力してください。
 
   = render "devise/registrations/footer-signup" 

--- a/app/views/users/registrations/new_3.html.haml
+++ b/app/views/users/registrations/new_3.html.haml
@@ -1,1 +1,54 @@
-smsだよ
+.member-sms-wrapper
+  .member-sms-confirmation-header
+    .sms-confirmation-merukari-logo
+      = image_tag "merikari4.png", size:'185x49',class: "confirmation_merukari"
+    .member-sms-confirmation-progress
+      %li.progress
+        会員情報
+        .progress-parts_1
+      %li.progress-here
+        電話番号認証
+        .progress-parts_here
+      %li.progress
+        お届け先住所入力
+        .progress-parts
+      %li.progress
+        支払い方法
+        .progress-parts
+      %li.progress
+        完了
+        .progress-parts_5
+  .member-mobile-number-menu
+    .member-mobile-number-menu__contents
+      .member-mobile-number-menu__top
+        電話番号認証
+      .member-mobile-number-menu__first
+        .member-mobile-number-menu__main
+          .member-mobile-number-menu__form
+            %label 認証番号
+            %input.input-sms-mobile-number{:name => "number", :placeholder => "認証番号を入力", :type => "number", :value => ""}/
+            %p SMSで届いた認証番号を入力してください
+          .form-input-complete-button
+            認証して完了
+        .not-sms-number
+          .not-sms-number__text
+            %label 30秒たっても認証番号が届かない方へ
+            %p.to-call 電話で認証番号を聞くこともできます。
+          .not-sms-number__button
+            電話で認証番号を聞く（通話無料）
+        .one-more-mobile-number
+          .one-more-mobile-number__text
+            %label 認証番号を再送することもできます。もう一度電話番号を入力して下さい。
+          %a.input-number-link 電話番号を再度入力する
+          %p.consent-message 
+            ※SMSが届かない場合は
+            %a.consent-link{:href => "https://www.mercari.com/jp/"}> SMS受信設定
+            を確認して、もう一度電話番号を入力してください。
+
+  = render "devise/registrations/footer-signup" 
+
+
+
+
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_091246) do
+ActiveRecord::Schema.define(version: 2019_11_04_050158) do
+
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prefecture_id"
+    t.string "city"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
What
メールアドレスで新規登録する場合の、SMS認証ページ（https://www.mercari.com/jp/signup/sms_confirmation/sms/）
のマークアップを行いました。

Why
携帯電話番号でのSMS認証番号を入力するフォーム、認証番号が届かない場合、電話をかけて認証番号を確認する方法があり、お客様の状況に備えてあります。

見た目を作っているので、各リンクは仮で設定しています。サーバーサイドの設定の時に正しいものに変更する予定です。

●作成した見た目はこちらです。
上　https://gyazo.com/5b86074c9876733cdf51cea0092a016b
下　https://gyazo.com/dd2442a30465c8ae1462f33f2df8f554