### PR TITLE
nameカラムをusersテーブルから削除

### DIFF
--- a/db/migrate/20191112094540_remove_name_from_users.rb
+++ b/db/migrate/20191112094540_remove_name_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :name, :string
+  end
+end


### PR DESCRIPTION
What
usersテーブルからnameカラムを削除しました。

Why
デフォルトで入っていたnameカラムを削除しました。
$ rails generate migration RemoveNameFromUsers name:string