### PR TITLE
addressesテーブルにカラムを追加

### DIFF
--- a/db/migrate/20191112105804_add_column_to_addresses.rb
+++ b/db/migrate/20191112105804_add_column_to_addresses.rb
@@ -1,0 +1,10 @@
+class AddColumnToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :postal_cord, :integer,          null: false
+    add_column :addresses, :prefecture, :string,            null: false
+    add_column :addresses, :block, :string,                 null: false
+    add_column :addresses, :building, :string
+    add_column :addresses, :phone_number, :integer
+    add_reference :addresses, :user_id, foreign_key: true,  null: false
+  end
+end


### PR DESCRIPTION
What
addressesテーブルにカラムを追加しました。

Why
DB設計を基にaddressesテーブルにカラムを追加しました。
$ rails generate migration AddColumnToAddresses postal_cord:integer prefecture:string block:string building:string phone_number:integer user_id:references