### PR TITLE
addressテーブルのcityカラムのオプションを追加

### DIFF
--- a/db/migrate/20191112113827_change_column_to_addresses.rb
+++ b/db/migrate/20191112113827_change_column_to_addresses.rb
@@ -1,0 +1,13 @@
+class ChangeColumnToAddresses < ActiveRecord::Migration[5.2]
+
+  #変更内容
+  def up
+    change_column :addresses, :city, :string, null: false
+  end
+
+  #変更前
+  def down
+    change_column :addresses, :city, :string
+  end
+  
+end


### PR DESCRIPTION
What
addressesテーブルのcityカラムのオプションを追加しました。

Why
cityカラムにオプションのnull: falseを追加するマイグレーションを作成しました。
$ rails g migration ChangeColumnToAddresses