### PR TITLE
ページ遷移ボタンの設定やり直し

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,7 +6,7 @@
     .sign-up__btn
       .sign-up__new
         %p アカウントをお持ちでない方はこちら
-        %input.sign-up__link{ onclick: "location.href='./sign_up'", type: "button", value: "新規会員登録"}/
+        = button_to '新規会員登録', new_user_registration_path, method: :get, class: "sign-up__link"
       .log-in__menu
         .log-in__btn
           =link_to "https://www.facebook.com/", class: "log-in__btn log-in__btn--facebook" do


### PR DESCRIPTION
What
ログインページから新規会員登録ページへの遷移ボタンの設定を修正しました。

Why
inputを使ったボタンから、button_toとpathを使ったボタンに変えました。
= button_to '新規会員登録', new_user_registration_path, method: :get, class: "sign-up__link"
