### PR TITLE
gitignoreにenvを追記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ public/uploads/*
 
 config/secrets.yml
 
-.env
+\.env


### PR DESCRIPTION
What
envをリモートに上がらないようにしました。

Why
リモートに上がってしまった.envをgit rm --cached .envでgit管理下から外し、gitignoreを追記しました。