### PR TITLE
デプロイエラーのためancestryをコメントアウト

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
   has_many :items_categories
   has_many :items, through: :items_categories
-  has_ancestry
+  # has_ancestry
 end


### PR DESCRIPTION
What
デプロイでエラーが起きたのでancestryをコメントアウトします。

Why
Mysql2::Error: Key column 'ancestry' doesn't exist in table
キーカラム 'ancestry'はテーブルに存在しません
というエラーがでました。テーブルは作ってある...。確認のため一度コメントアウトします。