### PR TITLE
[WIP]途中：マイページのお支払方法機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,4 @@
 @import "showbuy";
 @import "users/member-all-done";
 @import "item/sell-btn";
+@import "mypage/showcard";

--- a/app/assets/stylesheets/mypage/_showcard.scss
+++ b/app/assets/stylesheets/mypage/_showcard.scss
@@ -1,0 +1,6 @@
+.wrapper-creditcard-shimo {
+  background-color: #f5f5f5;
+}
+  .show_card_info {
+    
+  }

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -13,10 +13,9 @@ class CardController < ApplicationController
       redirect_to action: "new" #もしpayjp-tokenが空（未入力？）ならnewアクションへ飛ぶ
     else
       customer = Payjp::Customer.create(  #payjp::Customer.createで顧客作成→()の情報で作成されたトークンを用いて顧客情報を導入している？
-        # description: '登録テスト',
         email: current_user.email,
         card: params['payjp-token'], #入力されたpayjp-token（params）を持ったcard
-        # metadata: {user_id: current_user.id} #user_id=current_user.idのメタデータ
+        metadata: {user_id: current_user.id} #user_id=current_user.idのメタデータ
       )
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save

--- a/app/views/card/index.html.haml
+++ b/app/views/card/index.html.haml
@@ -2,7 +2,7 @@
 -#   .main-header
 -#     = render 'items/main-header'
 
--#     = link_to 'クレジットカードを追加する', new_card_path, class:'mypage_add_card_btn'
+    = link_to 'クレジットカードを追加する', new_card_path, class:'mypage_add_card_btn'
     
 
 -#     .mypage-left

--- a/app/views/card/index.html.haml
+++ b/app/views/card/index.html.haml
@@ -1,0 +1,13 @@
+-# .wrapper-creditcard-shimo #ページ更新がうまくいかないのでコメントアウトして保留
+-#   .main-header
+-#     = render 'items/main-header'
+
+-#     = link_to 'クレジットカードを追加する', new_card_path, class:'mypage_add_card_btn'
+    
+
+-#     .mypage-left
+-#       = render 'profile/mypage-left'
+-#   .banner
+-#     = render 'items/banner'
+-#   .fotter  
+-#     = render 'items/footer'

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -1,7 +1,11 @@
 .wrapper-creditcard-shimo
   .main-header
     = render 'items/main-header'
+  
+  .mypage-left
+    = render 'profile/mypage-left'
 
+  .show_card_info
     %label 登録クレジットカード情報
     %br
     = "**** **** **** " + @default_card_information.last4
@@ -13,8 +17,7 @@
       %input{ type: "hidden", name: "card_id", value: "" }
       %button 削除する
 
-    .mypage-left
-      = render 'profile/mypage-left'
+
   .banner
     = render 'items/banner'
   .fotter  

--- a/app/views/profile/_mypage-left.html.haml
+++ b/app/views/profile/_mypage-left.html.haml
@@ -24,7 +24,9 @@
   %ul
     %li プロフィール
     %li 発送元•お届け先住所変更
-    %li 支払い方法
+    %li 
+      = link_to new_card_path, class:'list-logout' do
+        支払い方法
     %li メール/パスワード
     %li 本人情報
     %li 電話番号の確認

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get 'mypage/profile', action: :edit, controller: 'profile'
   get "logout" => "profile#logout"
   get 'mypage' => 'profile#mypage'
-  get 'mypage/card', action: :new, controller: 'card'
+  # get 'mypage/card', action: :index, controller: 'card'
   resources :items, only: [:index,:new,:search,:show,:create,:edit,:destroy]
   resources :buy, only: [:show]
   #ユーザー各種新規登録画面


### PR DESCRIPTION
What
マイページの支払い方法機能を実装しました。

Why
実装したこと：
新規登録で入力したカード情報が表示される
カード情報を削除できる
新しくカードを追加できる

できてないこと：
・カードを削除した後にカードを追加するボタンのみのページにとばして、違うカードを追加しようとすると一回ではできない。入力して追加ボタンを二回押さなければいけないので別の方法を考える。
・ビューがくずれている。