### PR TITLE
画像保存

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,7 @@ class ItemsController < ApplicationController
     @parents = Category.where(ancestry: nil).order("id ASC").limit(13)
     # @item.size
     # @item.brand
-    @item_photo = @item.photos.build #_buildの書き方でエラーが出ました。コネクトで聞いた結果、同じ意味である左記の記述で書いてあります。
+    @item_photo = @item.photos.build #子モデルのphotoを保存させるための記述。_buildの書き方でエラーが出ました。コネクトで聞いた結果、同じ意味である左記の記述で書いてあります。
   end
 
   def search
@@ -27,7 +27,6 @@ class ItemsController < ApplicationController
   end
 
   def create
-    binding.pry
     @item = Item.new(item_params)
       if @item.save
         redirect_to root_path
@@ -54,7 +53,7 @@ class ItemsController < ApplicationController
     size_attributes: [:id, :size],
     items_categories_atributes: [:item_id, :category_id] , 
     brand_attributes: [:id, :name], 
-    photos_attributes: [:id, :url], 
+    photos_attributes: [:id, :url],  #item.rbに記定義したphotos_attributesをここに書くことでparamsで持ってこています。
     ).merge(user_id: current_user.id, seller_id: current_user.id)
   end
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,5 +1,4 @@
 class Photo < ApplicationRecord
   belongs_to :item
-
-  mount_uploader :url, UrlUploader
+  mount_uploader :url, ImageUploader #  mount_uploaderとImageUploaderというものは固定です。imageカラムではなくurlカラム、だからと言って変更してはいけないそうです。
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -18,10 +18,10 @@
             .sell__container__form__upload__dropbox
               .sell__container__form__upload__dropbox__have
                 .previews
-                =f.fields_for :photo do |photo|
+                =f.fields_for :photos do |photo| #:photosというのはitem.rbに定義したアソシエーションこと。複数形で定義しているのでphotos
                   = photo.label :url, class: "sell__container__form__upload__dropbox__have__image-up" do
                     .sell__container__form__upload__dropbox__have__image-up__box-size
-                    = photo.file_field :url, class:'hidden'
+                    = photo.file_field :url, class:'hidden' 
                     %pre.sell__container__form__upload__dropbox__have__message
                       ドラッグアンドドロップ
                       またはクリックしてファイルをアップロード


### PR DESCRIPTION
#what
商品出品機能で、子モデルであるphotoモデルに画像を保存できるように実装しました。

ひとまず画像が保存できるようになりました。
他のテーブルにも保存できるように、実装を引き続き行います。