### PR TITLE
商品詳細ページに売り切れだとわかるようにしました

### DIFF
--- a/app/assets/stylesheets/item/_show.scss
+++ b/app/assets/stylesheets/item/_show.scss
@@ -27,6 +27,27 @@
             &__top{
               position: relative;
               overflow: hidden;
+              .item-box_photo__sold{
+                width: 0;
+                height: 0;
+                border-top: 60px solid #ea352d ;
+                border-right: 60px solid transparent;
+                border-bottom: 60px solid transparent;
+                border-left: 60px solid #ea352d ;
+                z-index:100;
+                position: absolute;
+                top: 0px;
+                // position: relative;
+                // top:-320px;
+                &__inner{
+                  transform: rotate(-45deg);
+                  font-size: 28px;
+                  margin:-35px 0px 0px -55px;
+                  color: #fff;
+                  letter-spacing: 2px;
+                  font-weight: 600;
+                }
+              } 
               &__active{
                 line-height: 0;
                 width: 100%;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,6 +49,7 @@ class ItemsController < ApplicationController
 
   def show
     @items = Item.find(params[:id])
+    @photo_data = Photo.find_by(item_id: @items.id) #photoモデルから出品アイテムのidと同じitem_idのレコードをひっぱてきて@photo_dateに渡す
     @shipment_area = @items.shipment_area #雉野追記、@itemsにあるshipment_areaのidだけを@shipment_areaに渡す
     @shipment_area_data = Prefecture.find_by(id: @shipment_area) #雉野追記、@shipment_areaのidで@Prefectureモデルから該当の都道府県を探して@shipment_area_dataに渡す
     @shipment_area_name = @shipment_area_data.name #雉野追記、Prefectureモデルから見つけた都道府県の名前だけを@shipment_area_nameに渡す
@@ -85,7 +86,7 @@ class ItemsController < ApplicationController
     @user = User.find(@items.seller_id)
     # binding.pry
     if @items.destroy
-      binding.pry
+      # binding.pry
       # flash[:notice] = "商品を削除しました"
       redirect_to root_path
       # binding.pry

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,12 +8,16 @@
       .item-box__main__photo
         .item-box__main__photo__owl-photo
           .item-box__main__photo__owl-photo__top
+            -if @items.buyer_id.present? #雉野追記,購入した商品にSOLD表示する 14行目まで
+              .item-box_photo__sold
+                .item-box_photo__sold__inner
+                  SOLD
             .item-box__main__photo__owl-photo__top__active
-              = image_tag 'item-photo', size:'300x300'
+              = image_tag "#{@photo_data.url}", size:'300x300'
         .item-box__main__photo__under-photo
           .item-box__main__photo__under-photo__small-photo
             .item-box__main__photo__under-photo__small-photo__picture
-              = image_tag 'item-photo', size:'60x60'
+              = image_tag "#{@photo_data.url}", size:'60x60'
       .item-box__main__item-table
         .item-box__main__item-table__list
           .item-box__main__item-table__list__left
@@ -86,7 +90,10 @@
         %button.seller_menu_btn__delete
           = link_to 'この商品を削除する', item_path, method: :delete, class:'default_btn_gray' #雉野追記ここまで
     .item-by-btn
-      = link_to "購入画面に進む", buy_item_path #雉野追記
+      - if @items.buyer_id.present?
+        こちらの商品は売切れです。
+      - else
+        = link_to "購入画面に進む", buy_item_path #雉野追記
     .item-discription
       .item-discription__inner
         = @items.description

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-
-ActiveRecord::Schema.define(version: 2019_12_24_131421) do
+ActiveRecord::Schema.define(version: 2019_12_26_094544) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"


### PR DESCRIPTION
What
商品詳細ページ（Item/show）でも商品が売り切れだとわかるようにしました。

Why
商品詳細ページの画像にSOLD表示、購入画面に進むボタンを「こちらの商品は売り切れです」に変えて購入ページに進めないようにしました。