### PR TITLE
ログインしずに購入ボタンを押すとログインページに移動する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,8 @@ class ItemsController < ApplicationController
 
   require 'payjp'
 
+  before_action :authenticate_user!, only: [:edit, :update, :destory, :buy, :pay]
+
   def index
     @items = Item.all.order("created_at DESC")
   end


### PR DESCRIPTION
What
ログインせずに商品購入ボタンを押すとログインページに移動するようにしました。

Why
登録情報がないユーザーは商品が購入できないようにしました。
items_controllerのbefore_action :authenticate_user!, only: [:edit, :update, :destory, :buy, :pay]の記述になります。