### PR TITLE
S3の設定を修正しました

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,7 +11,7 @@ amazon:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: an-northeast-1
+  region: ap-northeast-1
   bucket: merukari56a
 
 # Remember not to checkin your GCS keyfile to a repository


### PR DESCRIPTION
What
storage.ymlのリージョンのタイプミスを修正しました。

Why
本番環境で出品すると以下のエラーが出たので見直したところ、タイプミスをしていました...。

Failed to open TCP connection to merukari56a.s3.an-northeast-1.amazonaws.com:443 (getaddrinfo: Temporary failure in name resolution)
