### PR TITLE
SNS認証での新規登録、ログインの実装

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,6 @@ class User < ApplicationRecord
 
 
   #SNS認証のために記入
-
   def self.without_sns_data(auth) #self.find_oauth(auth)から飛んでくる
     #snsから取ってきたemailがuserモデルにあるか探してuserに渡す。なければnilが入る。
     user = User.where(email: auth.info.email).first
@@ -49,13 +48,11 @@ class User < ApplicationRecord
         user = User.new(
           nickname: auth.info.name, #snsから取ってきた名前がuserテーブルのnicknameになる
           email: auth.info.email, #snsから取ってきたメールアドレスがuserテーブルのemailになる
-          # password: Devise.friendly_token[0,20] #passwordは作れてもuser=の中には入らない？見つからない。他のカラムはnilになってでも全部出てくる...。
         )
         sns = SnsCredential.new(
           uid: auth.uid, #snsから取ってきたuidがsns_credentialsテーブルのuidになる
           provider: auth.provider, #snsから取ってきたproviderがsns_credentialsテーブルのproviderになる
         )
-         #ここから上の37行目のuser=にとぶ,そのあとまたここにきて87行目にとぶ
       end
       return { user: user ,sns: sns}
      
@@ -88,7 +85,7 @@ class User < ApplicationRecord
       
       user = with_sns_data(auth, snscredential)[:user] #57行目からきた場合、snsから取得したnicknameとemailが入っている。
       sns = snscredential #57行目からきた場合、snsから取得したuidとproviderが入っている
-       #57行目からきた場合、ここからomniauth_callback_controllerにとぶ
+
     else
       user = without_sns_data(auth)[:user] #35行目のuserで取得したuserが入っている
       sns = without_sns_data(auth)[:sns] #上に同じくsnsが入っている

--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -31,46 +31,46 @@
                 %label.label-1 お名前
                 %span.span-1 必須
                 = a.text_field :last_name, placeholder: '例) 山田', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.last_name'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.last_name'}
                 = a.text_field :first_name, placeholder: '例) 彩', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.first_name'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.first_name'}
               .member-new-name-kana
                 %label.label-1 お名前カナ
                 %span.span-1 必須
                 = a.text_field :last_name_kana, placeholder: '例) ヤマダ', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.last_name_kana'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.last_name_kana'}
                 = a.text_field :first_name_kana, placeholder: '例) アヤ', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.first_name_kana'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.first_name_kana'}
               .member-new-postal-code
                 %label.label-1 郵便番号
                 %span.span-1 必須
                 = a.text_field :postal_cord, placeholder: '例)123-4567', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.postal_cord'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.postal_cord'}
               .member-new-prefectures
                 %label.label-1 都道府県
                 %span.span-1 必須
                 = a.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: "---"}
-                = render partial: 'error_message', locals: {user: @user, column: 'address.prefecture_id'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.prefecture_id'}
               .member-new-municipal-district
                 %label.label-1 市町村区
                 %span.span-1 必須
                 = a.text_field :city, placeholder: '例)横浜市緑区', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.city'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.city'}
               .member-new-banchi
                 %label.label-1 番地
                 %span.span-1 必須
                 = a.text_field :block, placeholder: '例)青山1-1-1', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.block'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.block'}
               .member-new-building-name
                 %label.label-1 建物名
                 %span.span-2 任意
                 = a.text_field :building, placeholder: '例)柳ビル103', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.building'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.building'}
               .member-new-telephone-number
                 %label.label-1 電話番号
                 %span.span-2 任意
                 = a.text_field :phone_number, placeholder: '例)09012345678', class: 'input-registration-form'
-                = render partial: 'error_message', locals: {user: @user, column: 'address.phone_number'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'address.phone_number'}
             = f.submit '次に進む', class: :"button-next-page"
   = render "devise/registrations/footer-signup" 
 

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -30,26 +30,26 @@
             %label.label-1 ニックネーム
             %span.span-1 必須
             = f.text_field :nickname, placeholder: '例) メルカリ太郎', class: 'input-registration-form'
-            -# = render partial: 'error_message', locals: {user: @user, column: 'nickname'} #データを渡したいからlocalsオプション。 =render partioal:'xxx', locals:{key:data}
+            = render partial: 'signup/error_message', locals: {user: @user, column: 'nickname'}
           .member-mail
             %label.label-1 メールアドレス
             %span.span-1 必須
             = f.email_field :email, placeholder: 'PC・携帯どちらでも可', class: 'input-registration-form'
-            -# = render partial: 'error_message', locals: {user: @user, column: 'email'}
+            = render partial: 'signup/error_message', locals: {user: @user, column: 'email'}
           .member-password
             - if @sns.present?
             - else
               %label.label-1 パスワード
               %span.span-1 必須
               = f.password_field :password, placeholder: '7文字以上', class: 'input-registration-form'
-              -# = render partial: 'error_message', locals: {user: @user, column: 'password'}
+              = render partial: 'signup/error_message', locals: {user: @user, column: 'password'}
           .re-member-password
             - if @sns.present?
             - else
               %label.label-1 パスワード(確認)
               %span.span-1 必須
               = f.password_field :password_confirmation, placeholder: '7文字以上', class: 'input-registration-form'
-              -# = render partial: 'error_message', locals: {user: @user, column: 'password_confirmation'}  
+              = render partial: 'signup/error_message', locals: {user: @user, column: 'password_confirmation'}  
           .registration-identification
             %h3 本人確認
             %p 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客様に公開されることはありません。
@@ -60,16 +60,16 @@
             = f.text_field :last_name, placeholder: '例) 山田', class: 'input-kanji-myouji'
             = f.text_field :first_name, placeholder: '例) 彩', class: 'input-kanji-name'
             .error-messages_kanji
-              -# = render partial: 'error_message', locals: {user: @user, column: 'last_name'}
-              -# = render partial: 'error_message', locals: {user: @user, column: 'first_name'}
+              = render partial: 'signup/error_message', locals: {user: @user, column: 'last_name'}
+              = render partial: 'signup/error_message', locals: {user: @user, column: 'first_name'}
           .identification-name-kana
             %label.label-1 お名前カナ(全角)
             %span.span-1 必須
             = f.text_field :last_name_kana, placeholder: '例) ヤマダ', class: 'input-kana-myouji'
             = f.text_field :first_name_kana, placeholder: '例) アヤ', class: 'input-kana-name'
           .error-messages_kana
-            -# = render partial: 'error_message', locals: {user: @user, column: 'last_name_kana'}
-            -# = render partial: 'error_message', locals: {user: @user, column: 'first_name_kana'}
+            = render partial: 'signup/error_message', locals: {user: @user, column: 'last_name_kana'}
+            = render partial: 'signup/error_message', locals: {user: @user, column: 'first_name_kana'}
           .identification-birthday
             %label.label-1 生年月日
             %span.span-1 必須
@@ -81,9 +81,9 @@
               = f.select :birth_day, [["1", "1"], ["2", "2"], ["3", "3"], ["4", "4"], ["5", "5"], ["6", "6"], ["7", "7"], ["8", "8"], ["9", "9"], ["10", "10"], ["11", "11"], ["12", "12"], ["13", "13"], ["14", "14"], ["15", "15"], ["16", "16"], ["17", "17"], ["18", "18"], ["19", "19"], ["20", "20"], ["21", "21"], ["22", "22"], ["23", "23"], ["24", "24"], ["25", "25"], ["26", "26"], ["27", "27"], ["28", "28"], ["29", "29"], ["30", "30"], ["31", "31"]], {prompt: "---"}, class: "select-default_day select-text-default"
               %span.span_day 日
               .error-messages_birth
-                -# = render partial: 'error_message', locals: {user: @user, column: 'birth_year'}
-                -# = render partial: 'error_message', locals: {user: @user, column: 'birth_month'}
-                -# = render partial: 'error_message', locals: {user: @user, column: 'birth_day'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'birth_year'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'birth_month'}
+                = render partial: 'signup/error_message', locals: {user: @user, column: 'birth_day'}
           %p.identification-comments
             ※本人確認情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
           .no-robot

--- a/app/views/signup/sms_confirmation.html.haml
+++ b/app/views/signup/sms_confirmation.html.haml
@@ -28,7 +28,7 @@
           .member-mobile_number
             %label 携帯電話の番号(ハイフンはいりません)
             = f.text_field :phone_number, placeholder: '携帯電話の番号を入力', class: 'input-registration-form'
-            = render partial: 'error_message', locals: {user: @user, column: 'phone_number'}
+            = render partial: 'signup/error_message', locals: {user: @user, column: 'phone_number'}
             %p 本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用して認証を行います。
           = f.submit 'SMSを送信する', class: :"member-sms-confirmation-menu_button"
           %br


### PR DESCRIPTION
What
SNS認証での新規登録、ログインの実装を行いました。

Why
facebook、googleのアカウントを持っているユーザーはパスワードなしで登録できるようにしました。新規登録の手間を減らすことでユーザーの離脱率の減少に効果が期待できると思われます。