### PR TITLE
ビューの崩れ修正

### DIFF
--- a/app/assets/javascripts/image-up.js
+++ b/app/assets/javascripts/image-up.js
@@ -54,7 +54,7 @@ $(function(){
 
   $(document).on("click", '.item-image__operetion--delete', function(){
 
-    
+      
         
         //データ属性を取得してinputに送る
       function appendImages(array) {
@@ -82,7 +82,9 @@ $(function(){
       $(this).parent().parent().remove();
       appendImages(array);
       //sell__upload__drop-file-deleteをdocument.getElementsByClassNameで拾ってHTML.collectionに入れてる。変数inputを作る。
+      
       var  inputs = document.getElementsByClassName('sell__upload__drop-file-delete')
+      console.log(inputs);
       //Array.prototype.slice.callがHTMLコレクションを配列にするための記述。配列になったHTMLコレクションをindに代入。
       var ind = Array.prototype.slice.call(inputs)
       //indの中身を出していく。iが番号

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,3 +34,4 @@
 @import "item/edit-items";
 @import "item/_error_message";
 @import "mypage/add_card";
+@import "users/sub-main-header";

--- a/app/assets/stylesheets/item/_sell-btn.scss
+++ b/app/assets/stylesheets/item/_sell-btn.scss
@@ -10,22 +10,16 @@
   width: 160px;
   position: fixed;
   text-align: center;
-  z-index: 2;
   background-color: rgb(234, 53, 45);
   border-radius: 50%;
   &__box{
-    width: 160px;
-    height: 160px;
-    padding-top: 32px;
+    padding-top: 30px;
     color: white;
     &__name{
       color: white;
     }
     &__camera{
       font-size: 55px;
-      width: 160px;
-      height: 160px;
-      margin-top: -15px;
     }
   }
 }

--- a/app/assets/stylesheets/mypage/_logout.scss
+++ b/app/assets/stylesheets/mypage/_logout.scss
@@ -1,12 +1,13 @@
 .wrapper-logout{
   background-color: #f5f5f5;
   .pankuzu-logout{
-    display: block;
-    position: relative;
-    height: 48px;
-    width: 100%;
+    
+    // display: block;
+    // position: relative;
+    // height: 48px;
+    // width: 100%;
     background-color: white;
-    border-top: 1px solid #eee;
+    // border-top: 1px solid #eee;
     box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
     .breadcrumbs{
       height: 48px;

--- a/app/assets/stylesheets/mypage/_mypage.scss
+++ b/app/assets/stylesheets/mypage/_mypage.scss
@@ -6,7 +6,6 @@
     height: 48px;
     width: 100%;
     background-color: white;
-    border-top: 1px solid #eee;
     box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
     .breadcrumbs{
       height: 48px;

--- a/app/assets/stylesheets/users/_sub-main-header.scss
+++ b/app/assets/stylesheets/users/_sub-main-header.scss
@@ -1,0 +1,192 @@
+.sub-main-header{
+  background-color: white;
+  height: 100px;
+  width: 100%;
+  display: inline-block;
+  display: block;
+  position: relative;
+  z-index: 1;
+  border-bottom: solid rgba(0, 0, 0, 0.18) 0.5px;
+  font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
+  .sub-main-header-box{
+    position: absolute;
+    height: 100px;
+    width: 1040px;
+    left: 0;
+    right: 0;
+    margin: auto;
+    .sub-main-header-top{
+      height: 45px;
+      width: 1040px;
+      margin-top: 5px;
+      display: flex;
+      &__icon{
+        margin-right: 30px;
+      }
+      &__form{
+        height: 40px;
+        width: 840px;
+        input{
+          width: 841px;
+          height: 40px;
+          margin-left: 30px;
+        }
+      }
+      &__search{
+        cursor: pointer;
+        color: rgb(204, 204, 204);
+        margin-top: 12px;
+        
+      }
+      &__search:hover{
+        color: red;
+      }
+    }
+    .sub-main-header-under{
+      color: black;
+      height: 45px;
+      width: 1040px;
+      position: relative;
+      margin-top: 5px;
+      &__left{
+        float: left;
+        display: flex;
+        height: 44px;
+        width: 340px;
+        position: relative;
+        &__category{
+          margin-right: 20px;
+          font-size: 14px;
+          font-weight: 600;
+          line-height: 36px;
+          cursor: pointer;
+          &__list-ul{
+            color: rgb(234, 53, 45);
+            font-size: 14px;
+            font-weight: 600;
+          }
+        }
+        &__category:hover{
+          color: #0099e8;
+          }
+        &__brand{
+          margin-left: 20px;
+          line-height: 36px;
+          font-size: 14px;
+          font-weight: 600;
+          height: 44px;
+          width: 149px;
+          cursor: pointer;
+          &__tag{
+            color: rgb(234, 53, 45);
+          }
+        }
+        &__brand:hover{
+          color: #0099e8;
+          }
+      }
+      &__right{
+        height: 44px;
+        width: 540px;
+        display: flex;
+        position: relative;
+        left:167px;
+        line-height: 36px;
+        text-align: right;
+        font-size: 14px;
+          &__good{
+            height: 44px;
+            width: 127px;
+            cursor: pointer;
+            &__heart{
+              color: rgb(204, 204, 204);
+            }
+          }
+          &__good:hover{
+            color: #0099e8;
+            i{
+              color: #0099e8;
+            }
+          }
+          &__notice{
+            height: 44px;
+            width: 111px;
+            cursor: pointer;
+            &__bell{
+              color: rgb(204, 204, 204);
+            }
+          }
+          &__notice:hover{
+            color: #0099e8;
+            i{
+              color: #0099e8;
+            }
+            }
+          &__todo{
+            height: 44px;
+            width: 157px;
+            cursor: pointer;
+            &__check{
+              color: rgb(204, 204, 204);
+            }
+          }
+          &__todo:hover{
+            color: #0099e8;
+            i{
+              color: #0099e8;
+            }
+            }
+        &__mypage{
+          height: 44px;
+          width: 200px;
+          cursor: pointer;
+          position: absolute;
+          right: 10px;
+            .sub-mypage-link{
+              height: 44px;
+              width: 110px;
+              text-decoration: none;
+              color: black;
+              .sub-user-icon{
+                color: rgb(204, 204, 204);
+              }
+            }
+            .post_new {
+              display: inline-block;
+              margin-right: 5px;
+              border: solid 1px;
+              border-radius: 5px;
+              line-height: 30px;
+              text-decoration: none;
+              text-align: center;
+              width: 106px;
+              color: rgb(234, 53, 45);
+              background-color: rgb(234, 53, 45);
+              font-size: 14px;
+              color: white;
+            }
+          
+            .post_login {
+              display: inline-block;
+              border: solid 1px;
+              border-radius: 5px;
+              line-height: 30px;
+              text-decoration: none;
+              text-align: center;
+              width: 76px;
+              color: #0099e8;
+              font-size: 14px;
+          }
+
+        }
+        
+        &__mypage:hover{
+          color: #0099e8;
+          i{
+            color: #0099e8;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/views/items/_sub-main-header.html.haml
+++ b/app/views/items/_sub-main-header.html.haml
@@ -1,0 +1,38 @@
+.sub-main-header
+  .sub-main-header-box
+    .sub-main-header-top
+      .sub-main-header-top__icon
+        = link_to image_tag("merikari4.png", size:'134x36',class: "sub-my_merukari"), root_path
+      .sub-main-header-top__form
+        %input.form_input{:type => "text", :value => "何かお探しですか？"}
+      = fa_icon "search", class:"sub-main-header-top__search"
+    .sub-main-header-under
+      .sub-main-header-under__left
+        .sub-main-header-under__left__category
+          .sub-parent-list
+          =fa_icon 'list-ul', class: "sub-main-header-under__left__category__list-ul"
+          カテゴリーから探す
+          -# = render 'category-Jquery' //カテゴリのナビゲーションバーの表示です
+        .sub-main-header-under__left__brand
+          =fa_icon "tag", class: "sub-main-header-under__left__brand__tag"
+          ブランドから探す
+      .sub-main-header-under__right
+        - if user_signed_in?
+          .sub-main-header-under__right__good
+            =fa_icon "heart", class: "sub-main-header-under__right__good__heart"
+            いいね！一覧
+          .sub-main-header-under__right__notice 
+            =fa_icon "bell", class: "sub-main-header-under__right__notice__bell"
+            お知らせ    
+          .sub-main-header-under__right__todo
+            =fa_icon "check", class: "sub-main-header-under__right__todo__check"
+            やることリスト
+        .sub-main-header-under__right__mypage
+          -if user_signed_in?
+            = link_to mypage_path, class:'sub-mypage-link' do
+              =fa_icon "user",class:'sub-user-icon'
+              マイページ
+          -else
+            = link_to "新規会員登録", signup_path, class: 'sub-post_new'
+            = link_to "ログイン", new_user_session_path, class: 'sub-post_login'
+          

--- a/app/views/profile/logout.html.haml
+++ b/app/views/profile/logout.html.haml
@@ -1,6 +1,6 @@
 .wrapper-logout
   .header-logout
-    = render 'items/main-header'
+    = render 'items/sub-main-header'
   .pankuzu-logout
     - breadcrumb :logout
     = breadcrumbs pretext: "",separator: " &rsaquo; "

--- a/app/views/profile/mypage.html.haml
+++ b/app/views/profile/mypage.html.haml
@@ -1,6 +1,6 @@
 .wrapper-mypage
   .main-header-logout
-    = render 'items/main-header'
+    = render 'items/sub-main-header'
   .pankuzu-mypage
     - breadcrumb :mypage
     = breadcrumbs pretext: "",separator: " &rsaquo; "


### PR DESCRIPTION
#what
・出品ボタンのビューの修正
・パンくずリストがある場合のヘッダーのビューの修正
以上２箇所のビューの崩れを修正しました。

indexで使われてるヘッダーをマイページ、ログアウトページなどパンくずリストが表示されるページで、box-shadowが邪魔をして空白が出来ていたので
「パンくずリストがある場合に使用するヘッダー」を作成しました。

もし抜けているページがありましたら、= render "items/sub-main-header" で修正をよろしくお願います！

https://gyazo.com/3d98f263a678a8858ed928dd8e1774c8